### PR TITLE
docs: EasyAntiCheat setup guide

### DIFF
--- a/EAC_Setup_Guide.md
+++ b/EAC_Setup_Guide.md
@@ -1,0 +1,33 @@
+# EasyAntiCheat (UberStrike) — setup steps
+
+Short version. Full detail is in Epic's docs: <https://dev.epicgames.com/docs/game-services/anti-cheat>
+
+## 1. Epic dev portal (one-time)
+- Go to: dev.epicgames.com/portal → org **UberStrikeTeam** → product **UberStike4.3Server**
+- Enable it: left sidebar → **Epic Online Services → Anti-Cheat** → turn Anti-Cheat on
+- Permission: org admin → give each dev the **Anti-Cheat** role (otherwise the **Integrity keys** button is greyed: "your account does not have access")
+- Get keys: **Anti-Cheat → Integrity keys → Download**. You get:
+  - `base_private.key` ← **SECRET. Never commit / share.**
+  - `base_public.cer` ← the certificate
+- Get credentials: **Product Settings** → copy ProductId, SandboxId, DeploymentId, ClientId, ClientSecret
+
+## 2. Unity client (one-time)
+- Install the EOS plugin: `com.playeveryware.eos`
+- Menu **EOS Plugin → Configuration**:
+  - paste ProductId / SandboxId / DeploymentId / ClientId / ClientSecret
+  - tick **Use EAC**
+  - **Path to EAC private key** = `base_private.key`
+  - **Path to EAC Certificate** = `base_public.cer`
+
+## 3. Build
+- Build **Windows standalone** (IL2CPP). The integrity tool runs automatically on build and produces **`EACBootstrapper.exe`** + an `EasyAntiCheat/` folder.
+
+## 4. Activate
+- Portal → Anti-Cheat: after one client build is launched/registered, **activate the client module**. Then **Client Protection** unlocks → turn it on.
+
+## 5. Test
+- Run **`EACBootstrapper.exe`** (not the game .exe).
+- If it says "EAC not installed": in that folder, run as admin → `EasyAntiCheat_EOS_Setup.exe install prod-fn`
+- Tamper a protected file → relaunch → integrity violation is logged. Done.
+
+> Note: this is **client protection only** (anti-tamper of the real client). It does NOT stop a custom client speaking the protocol — that needs server-side validation (separate work).


### PR DESCRIPTION
## What
Adds **`EAC_Setup_Guide.md`**  a short, step-by-step guide for getting EasyAntiCheat working on the UberStrike client via the EOS plugin: enabling Anti-Cheat in the Epic portal, granting team members access, downloading the **integrity keys** (`base_private.key` / `base_public.cer`), wiring them in Unity, building the bootstrapper, and testing.

## Why
Keeps the setup steps next to the code instead of in chat. Points to Epic's official docs for full detail.

## Safety
**Docs-only  one markdown file, no code.** Contains **no secrets**: it tells you which IDs/keys to copy from the portal, it does not embed any. The private key is explicitly flagged as never-commit.

> Scope note: this documents EAC **client protection** only. The actual EOS-plugin integration is separate (branch `easyanticheat-test`), and client integrity does not replace server-side validation.

